### PR TITLE
Update the latest stable version number & add a extra link.

### DIFF
--- a/CYANOGENMOD_FREENODE_TOPIC.mkdn
+++ b/CYANOGENMOD_FREENODE_TOPIC.mkdn
@@ -22,7 +22,7 @@ Trebuchet: Development of CM9's launcher application
 
 Stable Versions
 ------------------
-Android 4.2 - 10.1.1
+Android 4.2 - 10.1.2
 
 Android 4.1 - 10.0.0
 
@@ -54,3 +54,5 @@ Other useful links
 [Wiki](http://goo.gl/fUQ4)
 
 [Nightly Changelog](http://changelog.bbqdroid.org/)
+
+[Github](https://github.com/CyanogenMod)


### PR DESCRIPTION
Just a minor update to the Stable Versions section for Android 4.2 and added a link to the CyanogenMod GitHub.
