### PR TITLE
Change broken "wiki" link to something more useful

### DIFF
--- a/CYANOGENMOD_FREENODE_TOPIC.mkdn
+++ b/CYANOGENMOD_FREENODE_TOPIC.mkdn
@@ -54,7 +54,7 @@ Other useful links
 
 [Forum](http://goo.gl/WpNQ)
 
-[Wiki](http://goo.gl/fUQ4)
+[Wiki](http://wiki.cyanogenmod.org/w/Development)
 
 [Nightly Changelog](http://changelog.bbqdroid.org/)
 


### PR DESCRIPTION
Update to replace the older link:

```
[Wiki](http://goo.gl/fUQ4)
```

That went to a broken page:

Main Page?title=Main Page "There is currently no text in this page. You can search for this page title in other pages, or search the related logs, but you do not have permission to create this page."
